### PR TITLE
[WFLY-2640] Unable to add cached-connection-manager after removing it once

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/subsystems/jca/JcaCachedConnectionManagerDefinition.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/jca/JcaCachedConnectionManagerDefinition.java
@@ -32,6 +32,7 @@ import org.jboss.as.controller.SimpleOperationDefinition;
 import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.client.helpers.MeasurementUnit;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.transform.description.DiscardAttributeChecker;
 import org.jboss.as.controller.transform.description.ResourceTransformationDescriptionBuilder;
@@ -46,12 +47,16 @@ import static org.jboss.as.connector.subsystems.jca.Constants.CACHED_CONNECTION_
 public class JcaCachedConnectionManagerDefinition extends SimpleResourceDefinition {
     protected static final PathElement PATH_CACHED_CONNECTION_MANAGER = PathElement.pathElement(CACHED_CONNECTION_MANAGER, CACHED_CONNECTION_MANAGER);
     static final JcaCachedConnectionManagerDefinition INSTANCE = new JcaCachedConnectionManagerDefinition();
+    private static final SimpleOperationDefinition ADD_DEFINITION = new SimpleOperationDefinitionBuilder(ModelDescriptionConstants.ADD, JcaExtension.getResourceDescriptionResolver(""))
+            .setPrivateEntry()
+            .build();
+    private static final SimpleOperationDefinition REMOVE_DEFINITION = new SimpleOperationDefinitionBuilder(ModelDescriptionConstants.REMOVE, JcaExtension.getResourceDescriptionResolver(""))
+            .setPrivateEntry()
+            .build();
 
     private JcaCachedConnectionManagerDefinition() {
         super(PATH_CACHED_CONNECTION_MANAGER,
-                JcaExtension.getResourceDescriptionResolver(PATH_CACHED_CONNECTION_MANAGER.getKey()),
-                CachedConnectionManagerAdd.INSTANCE,
-                ReloadRequiredRemoveStepHandler.INSTANCE);
+                JcaExtension.getResourceDescriptionResolver(PATH_CACHED_CONNECTION_MANAGER.getKey()));
     }
 
     @Override
@@ -72,6 +77,8 @@ public class JcaCachedConnectionManagerDefinition extends SimpleResourceDefiniti
     @Override
     public void registerOperations(ManagementResourceRegistration resourceRegistration) {
         super.registerOperations(resourceRegistration);
+        resourceRegistration.registerOperationHandler(ADD_DEFINITION, CachedConnectionManagerAdd.INSTANCE);
+        resourceRegistration.registerOperationHandler(REMOVE_DEFINITION, ReloadRequiredRemoveStepHandler.INSTANCE);
         resourceRegistration.registerOperationHandler(CcmOperations.GET_NUMBER_OF_CONNECTIONS.getOperation(), GetNumberOfConnectionsHandler.INSTANCE);
         resourceRegistration.registerOperationHandler(CcmOperations.LIST_CONNECTIONS.getOperation(), ListOfConnectionsHandler.INSTANCE);
 

--- a/connector/src/main/resources/schema/wildfly-jca_4_0.xsd
+++ b/connector/src/main/resources/schema/wildfly-jca_4_0.xsd
@@ -101,7 +101,14 @@
               </xs:annotation>
             </xs:element>
 
-            <xs:element name="cached-connection-manager" type="cached-connection-managerType" minOccurs="0" maxOccurs="1"></xs:element>
+            <xs:element name="cached-connection-manager" type="cached-connection-managerType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Cached connection manager settings for resource adapters. NOTE: This service is always available so there's no
+                        way to remove it.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
         </xs:sequence>
     </xs:complexType>
 


### PR DESCRIPTION
[WFLY-2640] Unable to add cached-connection-manager after removing it once

Issue: https://issues.jboss.org/browse/WFLY-2640
